### PR TITLE
Fix: Refactored for linting issues

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -159,7 +159,7 @@ new Promise((resolve, reject) => {
 			config.dependencyFilter = dependencyFilter();
 		}
 
-		return madge(src, config);
+		return madge(src, config, program);
 	})
 	.then((res) => {
 		if (!program.json && !program.dot) {
@@ -191,6 +191,15 @@ new Promise((resolve, reject) => {
 			return res;
 		}
 
+		if (program.image) {
+			return res.image(program.image).then((imagePath) => {
+				spinner.succeed(
+					`${chalk.bold('Image created at')} ${chalk.cyan.bold(imagePath)}`
+				);
+				return res;
+			});
+		}
+
 		if (program.circular) {
 			const circular = res.circular();
 
@@ -202,25 +211,7 @@ new Promise((resolve, reject) => {
 				exitCode = 1;
 			}
 
-			if (program.image) {
-				return res.circularImage(program.image).then((imagePath) => {
-					spinner.succeed(
-						`${chalk.bold('Image created at')} ${chalk.cyan.bold(imagePath)}`
-					);
-					return res;
-				});
-			}
-
 			return res;
-		}
-
-		if (program.image) {
-			return res.image(program.image).then((imagePath) => {
-				spinner.succeed(
-					`${chalk.bold('Image created at')} ${chalk.cyan.bold(imagePath)}`
-				);
-				return res;
-			});
 		}
 
 		if (program.dot) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -36,10 +36,13 @@ class Madge {
 	 * @api public
 	 * @param {String|Array|Object} path
 	 * @param {Object} config
+	 * @param {Object} program
 	 * @return {Promise}
 	 */
-	constructor(path, config) {
+	constructor(path, config, program) {
+
 		this.skipped = [];
+		this.program = program;
 
 		if (!path) {
 			throw new Error('path argument not provided');
@@ -149,24 +152,28 @@ class Madge {
 			return Promise.reject(new Error('imagePath not provided'));
 		}
 
-		return graph.image(this.obj(), this.circular(), imagePath, this.config);
-	}
+		let dependencyGraph = this.obj();
 
-	circularImage(imagePath) {
-		if (!imagePath) {
-			return Promise.reject(new Error('imagePath not provided'));
+		if (this.program && this.program.circular) {
+			dependencyGraph = this.getCircularDependencyGraph();
 		}
 
-		const circular = this.circular();
+		return graph.image(dependencyGraph, this.circular(), imagePath, this.config);
 
-		const newTree = Object.entries(this.obj())
-			.filter(([k, v]) => circular.some((x) => x.includes(k)))
+	}
+
+	/**
+	 * Return circular dependency graph.
+	 * @api public
+	 * @return {Object}
+	 */
+	getCircularDependencyGraph() {
+		return Object.entries(this.obj())
+			.filter(([k]) => this.circular().some((x) => x.includes(k)))
 			.reduce((acc, [k, v]) => {
-				acc[k] = v.filter((x) => circular.some((y) => y.includes(x)));
+				acc[k] = v.filter((x) => this.circular().some((y) => y.includes(x)));
 				return acc;
 			}, {});
-
-		return graph.image(newTree, circular, imagePath, this.config);
 	}
 
 	/**
@@ -183,6 +190,7 @@ class Madge {
  * Expose API.
  * @param {String|Array} path
  * @param {Object} config
+ * @param {Object} program
  * @return {Promise}
  */
-module.exports = (path, config) => new Madge(path, config);
+module.exports = (path, config, program) => new Madge(path, config, program);


### PR DESCRIPTION
Hi,
I liked your original PR that adds the functionality to generate an SVG for circular dependencies,
https://github.com/pahen/madge/pull/224

However, the changes fail the Travis build due to linting issues.
I have refactored the code to resolve this. Please review it and give your feedback.
Let's try to fix all issues and push for the PR to get merged as I would like this feature available soon